### PR TITLE
fix: corrected typo in IMPACTS_lawnmower_P3_stacked_default.flt

### DIFF
--- a/flt_module/IMPACTS_5-Point_Leg.flt
+++ b/flt_module/IMPACTS_5-Point_Leg.flt
@@ -1,0 +1,6 @@
+#IMPACTS 5-Point Leg based on ER-2 leg length
+%leg_length,angle
+angle,leg_length*0.0833
+angle,leg_length*0.4167
+angle,leg_length*0.4167
+angle,leg_length*0.0833

--- a/flt_module/IMPACTS_lawnmower_P3_stacked_default.flt
+++ b/flt_module/IMPACTS_lawnmower_P3_stacked_default.flt
@@ -1,5 +1,5 @@
 #IMPACTS lawmower pattern P3 portion, with stacked legs and default distances in km
-%angle,top_altbot_alt
+%angle,top_alt,bot_alt
 angle, 112,top_alt
 angle+90,55,top_alt
 angle+180,112,top_alt


### PR DESCRIPTION
This corrects a type in the `IMPACTS_lawnmower_P3_stacked_default.flt` flight module.

This will also adds flight modules for IMPACTS that create 5-point legs where the 5 points are the ER-2 starts and end points, the P-3 start and end points, and a center point used for aircraft coordination and to serve as an anchor point for rotations.